### PR TITLE
Export the executable so that it can be run globally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.1
+
+- Add explicit executables config to the pubspec.yaml.
+
 # 1.1.0
 
 - Support reading generated to cache files from build_runner.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: import_path
-version: 1.1.0
+version: 1.1.1
 description: A tool to find the shortest import path from one dart file to another.
 homepage: https://github.com/jakemac53/import_path
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,3 +10,6 @@ dependencies:
   analyzer: '>=3.0.0 <5.0.0'
   package_config: ^2.0.0
   path: ^1.8.0
+
+executables:
+  import_path: import_path


### PR DESCRIPTION
Otherwise globally activating the package accomplishes nothing